### PR TITLE
Refactor "Call for" buttons

### DIFF
--- a/pages/Home/MainButtons.js
+++ b/pages/Home/MainButtons.js
@@ -1,0 +1,79 @@
+import React, { PureComponent } from 'react';
+import styled from 'styled-components';
+
+const Content = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  /* Aligns to header */
+  position: absolute;
+  top: 0;
+  left: 5rem;
+  height: 5rem;
+
+  @media (max-width: 768px) {
+    position: inherit;
+    height: auto;
+    flex-direction: column;
+    margin-bottom: 3.125rem;
+  }
+`;
+
+const ButtonLink = styled.a`
+  line-height: 1.8rem;
+  font-size: 1.5rem;
+  font-weight: 400;
+  padding: 0 1.25rem;
+  cursor: pointer;
+  text-decoration: none;
+
+  &:hover {
+    color: #fff;
+  }
+
+  &,
+  &:active {
+    color: #02f694;
+  }
+
+
+  & + & {
+    border-left: 2px solid #594a9d;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 1.125rem;
+    text-align: center;
+    width: 240px;
+    padding: 0.625rem 2.5rem;
+    border-radius: 1.5rem;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.2);
+    }
+
+    &,
+    &:active {
+      background-color: rgba(0, 0, 0, 0.1);
+    }
+
+    & + & {
+      border-left: none;
+      margin-top: 1.25rem;
+    }
+  }
+`;
+
+class MainButtons extends PureComponent {
+  render() {
+    return (
+      <Content>
+        <ButtonLink href="mailto:2018@fed.tw">Call For Sponsors</ButtonLink>
+        <ButtonLink href="mailto:2018@fed.tw">Call For Speakers</ButtonLink>
+      </Content>
+    );
+  }
+}
+
+export default MainButtons;

--- a/pages/Layout/Header.js
+++ b/pages/Layout/Header.js
@@ -16,47 +16,12 @@ const Content = styled.div`
   }
 `;
 
-const TopMenu = styled.div`
-  display: flex;
-`;
-
-const Menu = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-left: 10px;
-`;
-
-const MenuItem = styled.a`
-  line-height: 1.8rem;
-  font-size: 1.5rem;
-  font-weight: 400;
-  color: #02f694;
-  border-left: 2px solid #594a9d;
-  padding: 0 1.25rem;
-  cursor: pointer;
-  text-decoration: none;
-
-  &:hover {
-    color: #ffffff;
-  }
-
-  &:first-child {
-    border: none;
-  }
-`;
 
 class Header extends PureComponent {
   render() {
     return (
       <Content>
-        <TopMenu>
-          <Burger />
-          <Menu>
-            <MenuItem href="mailto:2018@fed.tw">Call For Sponsors</MenuItem>
-            <MenuItem href="mailto:2018@fed.tw">Call For Speakers</MenuItem>
-          </Menu>
-        </TopMenu>
+        <Burger />
         <BuyTicket />
       </Content>
     );

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,6 +4,7 @@ import { injectGlobal } from 'styled-components';
 import Wrapper from './Layout/Wrapper';
 import Header from './Layout/Header';
 import Main from './Home/Main';
+import MainButtons from './Home/MainButtons';
 import Footer from './Home/Footer';
 
 // eslint-disable-next-line no-unused-expressions
@@ -24,6 +25,7 @@ export default () => (
   <Wrapper>
     <Header />
     <Main />
+    <MainButtons />
     <Footer />
   </Wrapper>
 );


### PR DESCRIPTION
- Move these two buttons out from `<Header>` component, and named as `<MainButtons>`. 

- Fit the mobile design (#33).
  <img width="171" alt="37043051-b03261de-219a-11e8-81c0-c612b4d8476c" src="https://user-images.githubusercontent.com/5558360/37084142-b0069152-222c-11e8-874c-03459c5b210e.png">

- This component is positioned as absolute and align to the header in desktop view.
  <img width="582" alt="37043107-cd7688a6-219a-11e8-9444-2c06763bea2d-1" src="https://user-images.githubusercontent.com/5558360/37084239-e753c116-222c-11e8-981d-47f5260d19b5.png">


